### PR TITLE
Fixed issue with missin missing :

### DIFF
--- a/template.js
+++ b/template.js
@@ -30,7 +30,7 @@
 
     // Default options
     var defaults = {
-		initClass = 'my-plugin-class',
+		initClass: 'my-plugin-class',
 		afterCreateFunction : null,
 		beforeCreateFunction : null
     };


### PR DESCRIPTION
 On line 33, in the default options there was an equal sign instead of a colon.